### PR TITLE
feat: manage show linked account via getConfig

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -804,16 +804,18 @@ class AccountSettingsPage extends React.Component {
           />
         </div>
 
-        <div className="account-section pt-3 mb-5" id="linked-accounts" ref={this.navLinkRefs['#linked-accounts']}>
-          <h2 className="section-heading h4 mb-3">{this.props.intl.formatMessage(messages['account.settings.section.linked.accounts'])}</h2>
-          <p>
-            {this.props.intl.formatMessage(
-              messages['account.settings.section.linked.accounts.description'],
-              { siteName: getConfig().SITE_NAME },
-            )}
-          </p>
-          <ThirdPartyAuth />
-        </div>
+        {getConfig().ENABLE_LINKED_ACCOUNTS && (
+          <div className="account-section pt-3 mb-5" id="linked-accounts" ref={this.navLinkRefs['#linked-accounts']}>
+            <h2 className="section-heading h4 mb-3">{this.props.intl.formatMessage(messages['account.settings.section.linked.accounts'])}</h2>
+            <p>
+              {this.props.intl.formatMessage(
+                messages['account.settings.section.linked.accounts.description'],
+                { siteName: getConfig().SITE_NAME },
+              )}
+            </p>
+            <ThirdPartyAuth />
+          </div>
+        )}
 
         {getConfig().ENABLE_ACCOUNT_DELETION && (
           <div className="account-section pt-3 mb-5" id="delete-account" ref={this.navLinkRefs['#delete-account']}>

--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -53,11 +53,14 @@ const JumpNav = ({
             {intl.formatMessage(messages['account.settings.section.site.preferences'])}
           </NavHashLink>
         </li>
-        <li>
-          <NavHashLink to="#linked-accounts">
-            {intl.formatMessage(messages['account.settings.section.linked.accounts'])}
-          </NavHashLink>
-        </li>
+        {getConfig().ENABLE_LINKED_ACCOUNTS
+          && (
+          <li>
+            <NavHashLink to="#linked-accounts">
+              {intl.formatMessage(messages['account.settings.section.linked.accounts'])}
+            </NavHashLink>
+          </li>
+        )}
         {getConfig().ENABLE_ACCOUNT_DELETION
           && (
           <li>

--- a/src/account-settings/test/JumpNav.test.jsx
+++ b/src/account-settings/test/JumpNav.test.jsx
@@ -12,6 +12,7 @@ const IntlJumpNav = injectIntl(JumpNav);
 describe('JumpNav', () => {
   mergeConfig({
     ENABLE_ACCOUNT_DELETION: true,
+    ENABLE_LINKED_ACCOUNTS: true,
   });
 
   let props = {};
@@ -71,5 +72,39 @@ describe('JumpNav', () => {
     );
 
     expect(await screen.findByText('Delete My Account')).toBeVisible();
+  });
+  it('should not render LINKED ACCOUNTS link', async () => {
+    setConfig({
+      ENABLE_LINKED_ACCOUNTS: false,
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <IntlJumpNav {...props} />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(await screen.queryByText('Linked Accounts')).toBeNull();
+  });
+  it('should render LINKED ACCOUNTS link', async () => {
+    setConfig({
+      ENABLE_LINKED_ACCOUNTS: true,
+    });
+
+    props = {
+      ...props,
+    };
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <IntlJumpNav {...props} />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(await screen.findByText('Linked Accounts')).toBeVisible();
   });
 });


### PR DESCRIPTION

### Description

feat: manage show linked account via getConfig
#### How Has This Been Tested?

Add in the account mfe_config the desired config.

`ENABLE_LINKED_ACCOUNTS`  to control the show of this section in accounts mfe.

|Before 

<img width="1882" height="970" alt="2025-10-03_15-03" src="https://github.com/user-attachments/assets/f7778aac-59ae-422b-8c8c-d22aa8591c97" />

|After|

<img width="1868" height="990" alt="2025-10-03_15-02" src="https://github.com/user-attachments/assets/8d64b1da-9713-42e0-91ef-f7554cbaacaa" />


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.