### PR TITLE
feat: add static fields using MFE config

### DIFF
--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -1,4 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
+import { getConfig } from '@edx/frontend-platform';
 import { siteLanguageListSelector, siteLanguageOptionsSelector } from '../site-language';
 import { compareVerifiedNamesByCreatedDate } from '../../utils';
 
@@ -143,6 +144,11 @@ export const staticFieldsSelector = createSelector(
   mostRecentVerifiedNameSelector,
   (accountSettings, verifiedName) => {
     const staticFields = [];
+    // Add fields from config if present and is an array
+    if (getConfig().ACCOUNT_STATIC_FIELDS && Array.isArray(getConfig().ACCOUNT_STATIC_FIELDS)) {
+      staticFields.push(...getConfig().ACCOUNT_STATIC_FIELDS);
+    }
+
     if (accountSettings.profileDataManager) {
       staticFields.push('name', 'email', 'country');
     }
@@ -150,7 +156,7 @@ export const staticFieldsSelector = createSelector(
       staticFields.push('verifiedName');
     }
 
-    return staticFields;
+    return Array.from(new Set(staticFields)); // Remove duplicates, if any
   },
 );
 


### PR DESCRIPTION

### Description

Now with the MFE config field `ACCOUNT_STATIC_FIELDS`, that is a list you could manage static fields in account settings.

#### How Has This Been Tested?

####

Add the following mfe_config setting. 
```python
MFE_CONFIG["ACCOUNT_STATIC_FIELDS"] = ["name",]
```
You could test also with 'email' or 'country'
Before
<img width="1896" height="1010" alt="2025-10-06_11-27" src="https://github.com/user-attachments/assets/8f1eeefc-4984-43c7-bca5-9e403b5a8b0e" />


#### After

<img width="1748" height="935" alt="2025-10-06_11-43" src="https://github.com/user-attachments/assets/cb22b411-95ca-471f-93b5-9e6cad3305f0" />

**jira story**: https://edunext.atlassian.net/browse/FUTUREX-1445