### PR TITLE
feat: add frontend-essentials trans to MK cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,10 @@ pull_translations:
                translations/paragon/src/i18n/messages:paragon \
                translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
                translations/frontend-component-header/src/i18n/messages:frontend-component-header \
-               translations/frontend-app-account/src/i18n/messages:frontend-app-account
+               translations/frontend-app-account/src/i18n/messages:frontend-app-account \
+               translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-account
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-account frontend-essentials
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
## Description

This adds the frontend-essentials package to the pull_translation workflow. 

Issue # [1536](https://edunext.atlassian.net/browse/FUTUREX-1536)

## How to test
1. Run the following commands
``` bash
export PATH="$(pwd)/node_modules/.bin:$PATH"
make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository=nelc/futurex-translations --revision=open-release/redwood.master" pull_translations
```
2. Check the content of the folder` frontend-app-account/src/i18n/messages` 

<img width="584" height="469" alt="image" src="https://github.com/user-attachments/assets/1fa820ae-e3f3-4a6d-bacb-fa234f828721" />
